### PR TITLE
Parse default values

### DIFF
--- a/R/get_parameters.R
+++ b/R/get_parameters.R
@@ -68,6 +68,12 @@ get_parameters <- function() {
         val <- read.csv(val)
       }
     }
+
+    # check for default value if val is still NULL
+    if (is.null(val) && params[["default"]]) {
+      val <- params[["default"]]
+    }
+
     # append value to parsed_params
     parsed_params[[name]] <- val
   }

--- a/R/get_parameters.R
+++ b/R/get_parameters.R
@@ -42,7 +42,7 @@ get_parameters <- function() {
 
   # get all names from params_config that have a default value and are not optional to parse default values
   filtered_config_names <- names(Filter(function(x) !is.null(x$default) && !is.null(x$optional) && x$optional == FALSE, params_config))
-
+  print(filtered_config_names)
   # combine the two lists of parameter names
   params2parse <- unique(c(params_names, filtered_config_names))
 

--- a/R/get_parameters.R
+++ b/R/get_parameters.R
@@ -76,7 +76,7 @@ get_parameters <- function() {
       }
     }
 
-    # if val is still NULL, a default value exists for this parameter
+    # parse default values for parameters that are still NULL; a default value exists, as the parameter comes from the filtered_config_names
     if (is.null(val)) {
       val <- params_config[[name]]$default
     }

--- a/R/get_parameters.R
+++ b/R/get_parameters.R
@@ -41,7 +41,7 @@ get_parameters <- function() {
   params_config <- config$tools[[TOOL]]$parameters
 
   # get all names from params_config that have a default value and are not optional to parse default values
-  filtered_config_names <- names(Filter(function(x) !is.null(x$default) & !("$optional" %in% names(x)), params_config))
+  filtered_config_names <- names(Filter(function(x) !is.null(x$default) && !is.null(x$optional) && x$optional == FALSE, params_config))
 
   # combine the two lists of parameter names
   params2parse <- unique(c(params_names, filtered_config_names))

--- a/R/get_parameters.R
+++ b/R/get_parameters.R
@@ -41,10 +41,20 @@ get_parameters <- function() {
   params_config <- config$tools[[TOOL]]$parameters
 
   # get all names from params_config that have a default value and are not optional to parse default values
-  filtered_config_names <- names(Filter(function(x) !is.null(x$default) && !is.null(x$optional) && x$optional == FALSE, params_config))
-  print(filtered_config_names)
+  filtered_config_names <- sapply(names(params_config), function(name) {
+    x <- params_config[[name]]
+    if (!is.null(x$default) && (!exists("optional", x) || isFALSE(x$optional))) {
+      return(x$default)
+    } else {
+      return(NULL)
+    }
+  })
+
+  # Filter out the NULL values
+  filtered_config_names <- filtered_config_names[!sapply(filtered_config_names, is.null)]
+
   # combine the two lists of parameter names
-  params2parse <- unique(c(params_names, filtered_config_names))
+  params2parse <- unique(c(params_names, names(filtered_config_names)))
 
   # initiate list to save parsed parameters
   parsed_params <- list()
@@ -80,7 +90,7 @@ get_parameters <- function() {
     if (is.null(val)) {
       val <- params_config[[name]]$default
     }
-
+    
     # append value to parsed_params
     parsed_params[[name]] <- val
   }

--- a/R/get_parameters.R
+++ b/R/get_parameters.R
@@ -71,7 +71,8 @@ get_parameters <- function() {
 
     # check for default value if val is still NULL
     if (is.null(val) && params[["default"]]) {
-      val <- params[["default"]]
+      print(params_config[[name]][["default"]])
+      val <- params_config[[name]][["default"]]
     }
 
     # append value to parsed_params

--- a/R/get_parameters.R
+++ b/R/get_parameters.R
@@ -68,9 +68,9 @@ get_parameters <- function() {
         val <- read.csv(val)
       }
     }
-
+    print(val)
     # check for default value if val is still NULL
-    if (is.null(val) && params[["default"]]) {
+    if (is.null(val) && params_config[[name]][["default"]]) {
       print(params_config[[name]][["default"]])
       val <- params_config[[name]][["default"]]
     }

--- a/R/get_parameters.R
+++ b/R/get_parameters.R
@@ -40,13 +40,20 @@ get_parameters <- function() {
   config <- read_yaml(CONF_FILE)
   params_config <- config$tools[[TOOL]]$parameters
 
+  # get all names from params_config that have a default value and are not optional to parse default values
+  filtered_config_names <- names(Filter(function(x) !is.null(x$default) & !("$optional" %in% names(x)), params_config))
+
+  # combine the two lists of parameter names
+  params2parse <- unique(c(params_names, filtered_config_names))
+
   # initiate list to save parsed parameters
   parsed_params <- list()
 
   # parse parameters
-  for (name in params_names) {
+  for (name in params2parse) {
     # type of the parameter
     t <- params_config[[name]][["type"]]
+
     # get the value
     val <- params[[name]]
 
@@ -68,11 +75,10 @@ get_parameters <- function() {
         val <- read.csv(val)
       }
     }
-    print(val)
-    # check for default value if val is still NULL
-    if (is.null(val) && params_config[[name]][["default"]]) {
-      print(params_config[[name]][["default"]])
-      val <- params_config[[name]][["default"]]
+
+    # if val is still NULL, a default value exists for this parameter
+    if (is.null(val)) {
+      val <- params_config[[name]]$default
     }
 
     # append value to parsed_params

--- a/R/get_parameters.R
+++ b/R/get_parameters.R
@@ -64,8 +64,14 @@ get_parameters <- function() {
     # type of the parameter
     t <- params_config[[name]][["type"]]
 
-    # get the value
-    val <- params[[name]]
+    # get the value from parameters.json
+    if (name %in% names(params)) {
+       val <- params[[name]]
+
+    # if parameter is not included in parameters.json, go for default value in config
+    } else {
+       val <- params_config[[name]]$default
+    }
 
     # handle value specific types
     if (t == "enum") {
@@ -90,7 +96,7 @@ get_parameters <- function() {
     if (is.null(val)) {
       val <- params_config[[name]]$default
     }
-    
+
     # append value to parsed_params
     parsed_params[[name]] <- val
   }


### PR DESCRIPTION
With this PR, default parameters are parsed, if they are not optional.

@mmaelicke if you agree with this logic, I can also add this to the Python [json2args](https://github.com/hydrocode-de/json2args).

One problem I still see, is that when running a tool with the [tool-runner](https://github.com/hydrocode-de/tool-runner), the produced `/in/parameters.json` only includes the parameters in `kwargs`, default parameters are not included, do we want to change that?